### PR TITLE
nonzeronull

### DIFF
--- a/R/conduct_ri.R
+++ b/R/conduct_ri.R
@@ -22,7 +22,7 @@
 #' @param data A data.frame.
 #' @param sims the number of simulations. Defaults to 1000.
 #' @param progress_bar logical, defaults to FALSE.  Should a progress bar be displayed in the console?
-#' @param p Should "two-tailed", "upper", or "lower" p-values be reported? Defaults to "two-tailed"
+#' @param p Should "two-tailed", "upper", or "lower" p-values be reported? Defaults to "two-tailed".  For two-tailed p-values, whether or not a simulated value is as large or larger than the observed value is determined with respect to the distance to the sharp null.
 #'
 #' @export
 #'

--- a/R/conduct_ri.R
+++ b/R/conduct_ri.R
@@ -223,6 +223,7 @@ conduct_ri <- function(formula = NULL,
 
 
   ri_out$p <- p
+  ri_out$sharp_hypothesis <- sharp_hypothesis
 
   return(ri_out)
 }
@@ -237,7 +238,7 @@ plot.ri <- function(x, p = NULL, ...) {
     x$sims_df <-
       within(
         x$sims_df,
-        extreme <- abs(est_sim) >= abs(est_obs)
+        extreme <- abs(est_sim - x$sharp_hypothesis) >= abs(est_obs - x$sharp_hypothesis)
       )
   } else if (p == "lower") {
     x$sims_df <-
@@ -309,7 +310,7 @@ summary.ri <- function(object, p = NULL, ...) {
     object$sims_df <-
       within(
         object$sims_df,
-        extreme <- abs(est_sim) >= abs(est_obs)
+        extreme <- abs(est_sim - object$sharp_hypothesis) >= abs(est_obs - object$sharp_hypothesis)
       )
   } else if (p == "lower") {
     object$sims_df <-

--- a/man/conduct_ri.Rd
+++ b/man/conduct_ri.Rd
@@ -44,7 +44,7 @@ conduct_ri(formula = NULL, model_1 = NULL, model_2 = NULL,
 
 \item{progress_bar}{logical, defaults to FALSE.  Should a progress bar be displayed in the console?}
 
-\item{p}{Should "two-tailed", "upper", or "lower" p-values be reported? Defaults to "two-tailed"}
+\item{p}{Should "two-tailed", "upper", or "lower" p-values be reported? Defaults to "two-tailed".  For two-tailed p-values, whether or not a simulated value is as large or larger than the observed value is determined with respect to the distance to the sharp null.}
 }
 \description{
 This function makes it easy to conduct three kinds of randomization inference.

--- a/tests/testthat/test-nonzero_null.R
+++ b/tests/testthat/test-nonzero_null.R
@@ -1,7 +1,7 @@
 context("Two Arm Trial")
 
 
-test_that("Basic Two Arm Trial", {
+test_that("Non zero null", {
   N <- 100
   declaration <- randomizr::declare_ra(N = N, m = 50)
 

--- a/tests/testthat/test-nonzero_null.R
+++ b/tests/testthat/test-nonzero_null.R
@@ -1,0 +1,40 @@
+context("Two Arm Trial")
+
+
+test_that("Basic Two Arm Trial", {
+  N <- 100
+  declaration <- randomizr::declare_ra(N = N, m = 50)
+
+  Z <- randomizr::conduct_ra(declaration)
+  X <- rnorm(N)
+  Y <- .9 * X + -1 * Z + rnorm(N)
+  W <- runif(N)
+  df <- data.frame(Y, X, Z, W)
+
+  ri_out <-
+    conduct_ri(
+      formula = Y ~ Z,
+      declaration = declaration,
+      assignment = "Z",
+      sharp_hypothesis = 0,
+      data = df, sims = 100
+    )
+
+  plot(ri_out)
+  summary(ri_out)
+
+
+  ri_out <-
+    conduct_ri(
+      formula = Y ~ Z + X,
+      declaration = declaration,
+      assignment = "Z",
+      sharp_hypothesis = -1,
+      data = df, sims = 500
+    )
+
+  plot(ri_out)
+  summary(ri_out)
+
+  expect_true(TRUE)
+})

--- a/vignettes/ri2_vignette.R
+++ b/vignettes/ri2_vignette.R
@@ -83,7 +83,7 @@ N <- 100
 declaration <- declare_ra(N = N)
 X <- rnorm(N)
 Z <- conduct_ra(declaration)
-Y <- .9 * .2 * Z + .1 * X + -.5 * Z * X + rnorm(N)
+Y <- .9 + .2 * Z + .1 * X + -.5 * Z * X + rnorm(N)
 dat <- data.frame(X, Y, Z)
 
 # Observed ATE


### PR DESCRIPTION
This PR addresses a user issue:


> I wanted to flag a potential issue that I'd noticed. I believe that the p-value calculations aren't necessarily robust to different specifications of a sharp hypothesis that is not zero. In particular, in the conduct_ri.R function, there is a place to calculate a two-tailed p-value by tagging extreme observations: 
```

summary.ri <- function(object, p = NULL, ...) {
  if(is.null(p)){p <- object$p}
  if (p == "two-tailed") {
    object$sims_df <-
      within(
        object$sims_df,
        extreme <- abs(est_sim) >= abs(est_obs)
      )
  } else if (p == "lower") {
    object$sims_df <-
      within(
        object$sims_df,
        extreme <- est_sim <= est_obs
      )
  } else if (p == "upper") {
    object$sims_df <-
      within(
        object$sims_df,
        extreme <- est_sim >= est_obs
      )
  } else {
    stop('p must be either "two-tailed" (the default), "lower", or "upper".')
 }
```
> However, extreme values should be tagged as: extreme <- abs(est_sim - sharp_hypothesis) >= abs(est_obs - sharp_hypothesis) so that this p-value is valid for non-zero null hypotheses (looking for simulated values as or more extreme than the observed value).


I implemented the changes and added a test
