### PR TITLE
patch issue with condition names in conduct_conditional_ra()

### DIFF
--- a/R/conduct_conditional_ra.R
+++ b/R/conduct_conditional_ra.R
@@ -23,11 +23,13 @@ conduct_conditional_ra <-
 
 
       assignment_vec_new[assignment_vec %in% conditions] <-
-        simple_ra(
-          N = sum(assignment_vec %in% conditions),
-          prob_each = prob_each_local,
-          conditions = conditions,
-          check_inputs = FALSE
+        as.character(
+          simple_ra(
+            N = sum(assignment_vec %in% conditions),
+            prob_each = prob_each_local,
+            conditions = conditions,
+            check_inputs = FALSE
+          )
         )
     }
 
@@ -37,11 +39,13 @@ conduct_conditional_ra <-
       prob_each_local <- prob_each_local / (sum(prob_each_local))
 
       assignment_vec_new[assignment_vec %in% conditions] <-
-        complete_ra(
-          N = sum(assignment_vec %in% conditions),
-          prob_each = prob_each_local,
-          conditions = conditions,
-          check_inputs = FALSE
+        as.character(
+          complete_ra(
+            N = sum(assignment_vec %in% conditions),
+            prob_each = prob_each_local,
+            conditions = conditions,
+            check_inputs = FALSE
+          )
         )
     }
 
@@ -58,11 +62,13 @@ conduct_conditional_ra <-
         block_prob_each_local / rowSums(block_prob_each_local)
 
       assignment_vec_new[assignment_vec %in% conditions] <-
-        block_ra(
-          blocks = declaration$blocks[assignment_vec %in% conditions],
-          block_prob_each = block_prob_each_local,
-          conditions = conditions,
-          check_inputs = FALSE
+        as.character(
+          block_ra(
+            blocks = declaration$blocks[assignment_vec %in% conditions],
+            block_prob_each = block_prob_each_local,
+            conditions = conditions,
+            check_inputs = FALSE
+          )
         )
     }
 
@@ -72,11 +78,13 @@ conduct_conditional_ra <-
       prob_each_local <- prob_each_local / (sum(prob_each_local))
 
       assignment_vec_new[assignment_vec %in% conditions] <-
-        cluster_ra(
-          clusters = declaration$clusters[assignment_vec %in% conditions],
-          prob_each = prob_each_local,
-          conditions = conditions,
-          check_inputs = FALSE
+        as.character(
+          cluster_ra(
+            clusters = declaration$clusters[assignment_vec %in% conditions],
+            prob_each = prob_each_local,
+            conditions = conditions,
+            check_inputs = FALSE
+          )
         )
     }
 


### PR DESCRIPTION
When using multi-arm design `conduct_conditional_ra()` function is being called. In this function when permuted treatment vector for two conditions (which is a factor produced by `*_ra()`) is plugged into existing assignment vector (which is character vector) factor converts into numeric values first and then into character, e.g. in this chunk of code

```
assignment_vec_new[assignment_vec %in% conditions] <-
        simple_ra(
          N = sum(assignment_vec %in% conditions),
          prob_each = prob_each_local,
          conditions = conditions,
          check_inputs = FALSE
        )
```

One easy solution that is tested to work is to wrap `*_ra()` call into `as.character()` which is done in this pull request