### PR TITLE
Force bins in `plot.ri` to be an integer

### DIFF
--- a/R/conduct_ri.R
+++ b/R/conduct_ri.R
@@ -293,7 +293,7 @@ plot.ri <- function(x, p = NULL, ...) {
   summary_df$term <- rownames(summary_df)
 
   ggplot(x$sims_df, aes(x = est_sim, alpha = extreme)) +
-    geom_histogram(bins = max(30, nrow(x$sims_df) / 20)) +
+    geom_histogram(bins = max(30, floor(nrow(x$sims_df) / 20))) +
     geom_vline(
       data = summary_df,
       aes(


### PR DESCRIPTION
This is in response to `ggplot2` now forcing bins to be an integer. The plotting function fails with a large number of rows. 

Commit in ggplot2 is here: https://github.com/tidyverse/ggplot2/commit/06ca577762e9d4a7b0eeb29e0e5cfec378d69852