### PR TITLE
Floor the histogram bin count in plot.ri2 (#32)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 * Fixed silent outcome transformation dropping (#20): `log(Y) ~ Z` and other formula transformations now apply correctly via `model.frame()`.
 * Fixed S3 class name conflict with `bit::ri` (#28): class is now `"ri2"`.
 * Fixed histogram bar stacking (#6): use `fill` aesthetic instead of `alpha` in `plot.ri2()`.
+* Fixed `plot()` failing to draw any bars when the number of simulations is not a multiple of 20 (#32, thanks @mreece13): the bin count is now floored to a whole number, as `geom_histogram()` requires.
 * Replaced floating-point rounding hack with tolerance-based comparison in `summary.ri2()` and `plot.ri2()`.
 * Implemented `sampling_weights` argument (#16): pass a column name containing sampling weights; multiplied with the auto-computed IPW weights when both are present.
 * Removed `IPW_weights` argument: pre-specified IPW weights are incoherent for RI because weights must vary with each permuted assignment. IPW is always computed from the declaration via `obtain_condition_probabilities()`.

--- a/R/conduct_ri.R
+++ b/R/conduct_ri.R
@@ -244,8 +244,12 @@ plot.ri2 <- function(x, p = NULL, ...) {
   ))
   summary_df$term <- rownames(summary_df)
 
+  # geom_histogram() requires a whole number of bins, and nrow / 20 is
+  # fractional whenever the row count is not a multiple of 20.
+  n_bins <- max(30, floor(nrow(x$sims_df) / 20))
+
   ggplot(x$sims_df, aes(x = est_sim, fill = extreme)) +
-    geom_histogram(bins = max(30, nrow(x$sims_df) / 20)) +
+    geom_histogram(bins = n_bins) +
     geom_vline(
       data = summary_df,
       aes(xintercept = est_obs, linetype = Estimate, colour = Estimate),

--- a/tests/testthat/test-fixes.R
+++ b/tests/testthat/test-fixes.R
@@ -193,3 +193,19 @@ test_that("ri_ci interval contains the observed estimate", {
   expect_gte(beta_hat, out_ci$ci_lower)
   expect_lte(beta_hat, out_ci$ci_upper)
 })
+
+# GH PR #32 (mreece13): bins = nrow / 20 is fractional whenever the row count
+# is not a multiple of 20, and geom_histogram() requires a whole number.
+test_that("plot.ri2 builds when the simulation count is not a multiple of 20", {
+  set.seed(101)
+  N <- 60
+  decl <- randomizr::declare_ra(N = N, m = 30)
+  Z <- randomizr::conduct_ra(decl)
+  dat <- data.frame(Y = 0.3 * Z + rnorm(N), Z = Z)
+
+  out <- conduct_ri(Y ~ Z, declaration = decl, data = dat, sims = 1010)
+  expect_equal(nrow(out$sims_df) %% 20, 10)
+
+  built <- expect_no_warning(ggplot2::ggplot_build(plot(out)))
+  expect_gt(nrow(built$data[[1]]), 0)
+})


### PR DESCRIPTION
Closes #32 by applying its fix.

## The bug

`plot.ri2()` passed `bins = max(30, nrow(x$sims_df) / 20)` to `geom_histogram()`, which requires a whole number. The expression is fractional whenever the row count is not a multiple of 20, and `stat_bin()` then fails and the histogram renders with **no bars at all**:

```r
out <- conduct_ri(Y ~ Z, declaration = decl, data = dat, sims = 1010)
plot(out)
#> Computation failed in `stat_bin()`.
#> ! `bins` must be a whole number, not the number 50.5.
```

Any `sims` value leaving a remainder triggers it, so it is easy to hit by accident and the failure is a warning rather than an error, which makes it easy to miss.

## Credit

The diagnosis and the one-word fix are @mreece13's, from PR #32 (August 2024). That PR cannot be merged directly because it patches `plot.ri`, and the S3 class was renamed to `ri2` in this release to resolve the `bit::ri` collision (#28). The change is applied here against the current code with attribution in the commit and in NEWS.

## Test

Adds a regression test using `sims = 1010`. Confirmed it fails against the old expression with exactly the error above, and passes with the fix.

`R CMD check --as-cran`: 0 errors, 0 warnings, 0 notes.

## Related, not fixed here

The same expression derives the bin count from the total row count, but `plot.ri2()` facets by term, so a multi-arm result over-bins. A three-arm trial with 1000 sims yields 3000 rows and therefore 150 bins per facet, while each facet holds only 1000 observations. Left alone because it changes the appearance of existing multi-arm plots rather than fixing a failure, and that is a call worth making deliberately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)