### PR TITLE
Rebuild the design matrix when the assignment enters multiple terms

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # ri2 0.5.0
 
+* Fixed wrong null distributions when the assignment variable appears in more than one term of the formula, such as `Y ~ Z * X`. Only the assignment columns of the design matrix were updated for each permutation, so interaction columns kept their observed values and the design matrix disagreed with itself about what the assignment was. The resulting null distribution was too narrow and p-values were anti-conservative. Such formulas now rebuild the design matrix from the permuted assignment; the single-term case keeps the faster column-patching path.
 * Fixed multi-arm trial bug (#33): arms 2+ now each get a fresh conditional permutation matrix instead of reusing the first arm's matrix, giving correct p-values for all arms.
 * Fixed silent outcome transformation dropping (#20): `log(Y) ~ Z` and other formula transformations now apply correctly via `model.frame()`.
 * Fixed S3 class name conflict with `bit::ri` (#28): class is now `"ri2"`.

--- a/R/conduct_ri_ATE.R
+++ b/R/conduct_ri_ATE.R
@@ -36,6 +36,20 @@ conduct_ri_ATE <- function(formula,
   outcome_name <- names(mf)[1]
   design_matrix <- model.matrix.default(formula, data = data)
 
+  # When the assignment variable enters more than one term (an interaction such
+  # as Y ~ Z * X, or Y ~ Z + I(Z^2)), overwriting only the assignment columns
+  # would leave the other terms at their observed values, so the design matrix
+  # would disagree with itself about what the assignment was. Rebuild it from
+  # the permuted data in that case; patch columns in the common single-term
+  # case, which is much faster.
+  term_labels <- attr(stats::terms(formula, data = data), "term.labels")
+  assignment_terms <- vapply(
+    term_labels,
+    function(label) assignment %in% all.vars(str2lang(label)),
+    logical(1)
+  )
+  rebuild_design <- sum(assignment_terms) > 1
+
   condition_names <- sort(unique(assignment_vec))
 
   # Coefficient names ----
@@ -149,8 +163,15 @@ conduct_ri_ATE <- function(formula,
         Z_sim <- factor(Z_sim, levels = levels(assignment_vec))
       }
 
-      dm_sim <- design_matrix
-      dm_sim[, coefficient_names] <- model.matrix.default(~ Z_sim)[, -1]
+      dm_sim <- if (rebuild_design) {
+        data_sim <- data
+        data_sim[[assignment]] <- Z_sim
+        model.matrix.default(formula, data = data_sim)
+      } else {
+        dm <- design_matrix
+        dm[, coefficient_names] <- model.matrix.default(~ Z_sim)[, -1]
+        dm
+      }
 
       outcome_vec_sim <- if (all(sharp_hypothesis == 0)) {
         outcome_vec

--- a/tests/testthat/test-fixes.R
+++ b/tests/testthat/test-fixes.R
@@ -209,3 +209,47 @@ test_that("plot.ri2 builds when the simulation count is not a multiple of 20", {
   built <- expect_no_warning(ggplot2::ggplot_build(plot(out)))
   expect_gt(nrow(built$data[[1]]), 0)
 })
+
+# The design matrix used to be patched by overwriting only the assignment
+# columns, which left interaction columns at their observed values. The columns
+# then disagreed about what the assignment was, narrowing the null distribution
+# and making p-values anti-conservative.
+test_that("terms involving the assignment are rebuilt under permutation", {
+  set.seed(4)
+  N <- 60
+  decl <- randomizr::declare_ra(N = N, prob = 0.5)
+  Z1 <- randomizr::conduct_ra(decl)
+  Z2 <- rbinom(N, 1, 0.5)
+  Y <- 0.5 * Z1 + 0.8 * Z2 + 1.2 * Z1 * Z2 + rnorm(N)
+  dat <- data.frame(Y, Z1, Z2)
+
+  pm <- randomizr::obtain_permutation_matrix(decl, maximum_permutations = 25)
+
+  out <- conduct_ri(Y ~ Z1 * Z2, assignment = "Z1", declaration = decl,
+                    permutation_matrix = pm, IPW = FALSE, data = dat)
+
+  expected <- apply(pm, 2, function(z) coef(lm(Y ~ z * Z2))[["z"]])
+
+  expect_equal(out$sims_df$est_sim, expected, tolerance = 1e-8,
+               ignore_attr = TRUE)
+})
+
+test_that("additive covariate adjustment is unaffected by the rebuild path", {
+  set.seed(5)
+  N <- 60
+  decl <- randomizr::declare_ra(N = N, prob = 0.5)
+  Z <- randomizr::conduct_ra(decl)
+  X <- rnorm(N)
+  Y <- 0.4 * Z + 0.7 * X + rnorm(N)
+  dat <- data.frame(Y, Z, X)
+
+  pm <- randomizr::obtain_permutation_matrix(decl, maximum_permutations = 25)
+
+  out <- conduct_ri(Y ~ Z + X, assignment = "Z", declaration = decl,
+                    permutation_matrix = pm, IPW = FALSE, data = dat)
+
+  expected <- apply(pm, 2, function(z) coef(lm(Y ~ z + X))[["z"]])
+
+  expect_equal(out$sims_df$est_sim, expected, tolerance = 1e-8,
+               ignore_attr = TRUE)
+})


### PR DESCRIPTION
## The bug

`conduct_ri_ATE()` built each permutation's design matrix by overwriting only the assignment columns:

```r
dm_sim[, coefficient_names] <- model.matrix.default(~ Z_sim)[, -1]
```

If the assignment variable appears in more than one term, the other terms keep their **observed** values. For `Y ~ Z1 * Z2`, the `Z1:Z2` column still reflects the real `Z1` while the main effect is permuted, so the design matrix disagrees with itself about what the assignment was.

The null distribution is too narrow and p-values are **anti-conservative**:

| | Null SD |
|---|---|
| Before | 0.155 |
| After | 0.200 |
| Manual `lm()` refit per permutation | 0.202 |

This is not confined to factorial designs. It reaches any formula where the assignment enters twice, including `Y ~ Z * X`, the ordinary treatment-by-covariate heterogeneity specification. `ri_ci()` inherited it, since it calls `conduct_ri()`.

## The fix

Rebuild the design matrix from data with the assignment column replaced, which is exactly what `conduct_ri_f()` already does for the nested-model path. The single-term case keeps the column-patching path, so the common two-arm call does not slow down. A multi-level factor assignment is still a single term and is unaffected.

## Tests

Two tests over a fixed permutation matrix, compared against an `lm()` refit for each permuted assignment, so the comparison is exact rather than Monte Carlo:

- the interaction test **fails against the old code** and passes with the fix
- the additive `Y ~ Z + X` test passes under both, confirming the preserved fast path is genuinely equivalent

## Scope note

This overlaps #27, which asked for factorial designs. It does not implement a factorial interface; it makes the estimates and null distributions correct for formulas people can already write today. #27 stays open for the interface question.

`R CMD check --as-cran`: 0 errors, 0 warnings, 0 notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)