### PR TITLE
Choose histogram bins per panel, not from the total row count

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,7 @@
 * Fixed S3 class name conflict with `bit::ri` (#28): class is now `"ri2"`.
 * Fixed histogram bar stacking (#6): use `fill` aesthetic instead of `alpha` in `plot.ri2()`.
 * Fixed `plot()` failing to draw any bars when the number of simulations is not a multiple of 20 (#32, thanks @mreece13): the bin count is now floored to a whole number, as `geom_histogram()` requires.
+* `plot()` no longer over-bins multi-arm results. The bin count came from the total number of simulated estimates, but the plot facets by term, so a four-arm trial drew three times as many bins per panel as a two-arm trial over the same number of simulations per panel. Bins are now chosen per panel.
 * Replaced floating-point rounding hack with tolerance-based comparison in `summary.ri2()` and `plot.ri2()`.
 * Implemented `sampling_weights` argument (#16): pass a column name containing sampling weights; multiplied with the auto-computed IPW weights when both are present.
 * Removed `IPW_weights` argument: pre-specified IPW weights are incoherent for RI because weights must vary with each permuted assignment. IPW is always computed from the declaration via `obtain_condition_probabilities()`.

--- a/R/conduct_ri.R
+++ b/R/conduct_ri.R
@@ -255,9 +255,11 @@ plot.ri2 <- function(x, p = NULL, ...) {
   ))
   summary_df$term <- rownames(summary_df)
 
-  # geom_histogram() requires a whole number of bins, and nrow / 20 is
-  # fractional whenever the row count is not a multiple of 20.
-  n_bins <- max(30, floor(nrow(x$sims_df) / 20))
+  # Bins are chosen per panel, so divide by the number of terms rather than by
+  # the total row count: the plot facets by term, and each facet shows only its
+  # own simulations. geom_histogram() also requires a whole number.
+  n_terms <- length(unique(x$sims_df$term))
+  n_bins <- max(30, floor(nrow(x$sims_df) / n_terms / 20))
 
   ggplot(x$sims_df, aes(x = est_sim, fill = extreme)) +
     geom_histogram(bins = n_bins) +

--- a/tests/testthat/test-fixes.R
+++ b/tests/testthat/test-fixes.R
@@ -332,3 +332,23 @@ test_that("factorial via cells and a test_function matches manual permutation", 
   expect_equal(out$sims_df$est_sim, expected, tolerance = 1e-8,
                ignore_attr = TRUE)
 })
+
+# The bin count came from the total row count, but plot.ri2() facets by term, so
+# a multi-arm result got more bins per panel than a two-arm one over the same
+# number of simulations per panel.
+test_that("histogram bins do not scale with the number of arms", {
+  set.seed(102)
+  bins_drawn <- function(arms) {
+    decl <- randomizr::declare_ra(N = 150, num_arms = arms)
+    Z <- randomizr::conduct_ra(decl)
+    dat <- data.frame(Y = rnorm(150), Z = Z)
+    out <- conduct_ri(Y ~ Z, declaration = decl, data = dat, sims = 1000)
+    built <- ggplot2::ggplot_build(plot(out))
+    panel_1 <- built$data[[1]][built$data[[1]]$PANEL == 1, ]
+    length(unique(panel_1$x))
+  }
+
+  two_arm <- bins_drawn(2)
+  expect_equal(bins_drawn(3), two_arm)
+  expect_equal(bins_drawn(4), two_arm)
+})


### PR DESCRIPTION
## The problem

`plot.ri2()` facets by term, but `n_bins` came from `nrow(x$sims_df)`, which is `sims * (k - 1)`. Each panel only ever shows `sims` values, so bins scaled with the number of arms while the data per panel did not:

| Arms | Facets | Obs per facet | Bins before | Bins after |
|---|---|---|---|---|
| 2 | 1 | 1000 | 50 | 50 |
| 3 | 2 | 1000 | **100** | 50 |
| 4 | 3 | 1000 | **150** | 50 |

A four-arm trial drew three times the bins over the same amount of data per panel, giving spikier histograms with many near-empty bins.

## The fix

Divide by the number of terms, so bins are chosen for what a panel actually plots.

This is **cosmetic and it changes the appearance of existing multi-arm plots**, which is why it was raised separately rather than folded into the earlier crash fix. No p-value, estimate, or null distribution is affected.

The whole-number flooring from #32 is untouched, and `sims = 1010` still builds without the `stat_bin()` warning.

## Test

Asserts the bins drawn in the first panel are identical for two-, three-, and four-arm results. Verified it fails against the old expression (2 failures) and passes with the fix.

`R CMD check --as-cran`: 0 errors, 0 warnings, 0 notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)